### PR TITLE
Improvements to hexToRgb util

### DIFF
--- a/src/main/kotlin/gay/asoji/goveelightsdiscordbot/utils/HexColor.kt
+++ b/src/main/kotlin/gay/asoji/goveelightsdiscordbot/utils/HexColor.kt
@@ -1,26 +1,24 @@
 package gay.asoji.goveelightsdiscordbot.utils
 
 fun hexToRgb(hex: String): Triple<Int, Int, Int>? {
-    // Check if the hex string is valid
-    if (!hex.matches(Regex("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$"))) {
-        println("Invalid hex color code")
+    // Check if the hex string is valid syntax
+    if (!hex.matches(Regex("^#?([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$")))
         return null
-    }
 
     // Remove '#' symbol if present
-    val cleanHex = if (hex[0] == '#') hex.substring(1) else hex
+    val unpoundedHex = if (hex[0] == '#') hex.substring(1) else hex
 
     // Expand short hex format to full format if necessary
-    val fullHex = if (cleanHex.length == 3) {
-        cleanHex.map { it.toString() + it }.joinToString("")
+    val fullSizeHex = if (unpoundedHex.length == 3) {
+        unpoundedHex.map { it.toString() + it }.joinToString("")
     } else {
-        cleanHex
+        unpoundedHex
     }
 
-    // Convert hex to RGB
-    val red = fullHex.substring(0, 2).toInt(16)
-    val green = fullHex.substring(2, 4).toInt(16)
-    val blue = fullHex.substring(4, 6).toInt(16)
+    // Convert hex to RGB values
+    val red = fullSizeHex.substring(0, 2).toInt(16)
+    val green = fullSizeHex.substring(2, 4).toInt(16)
+    val blue = fullSizeHex.substring(4, 6).toInt(16)
 
     return Triple(red, green, blue)
 }


### PR DESCRIPTION
This will fix the requirement of pound symbol prefixing the hex code, improve colour accuracy and make the variables within the function easier to read at a glance.